### PR TITLE
Fix #18:  Frontend startet nicht

### DIFF
--- a/build/utils.js
+++ b/build/utils.js
@@ -17,7 +17,6 @@ exports.cssLoaders = function (options) {
   const cssLoader = {
     loader: 'css-loader',
     options: {
-      minimize: process.env.NODE_ENV === 'production',
       sourceMap: options.sourceMap
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Simon Neutert",
   "private": true,
   "scripts": {
+    "db": "node src/server.js",
     "dev": "node build/dev-server.js",
     "start": "node build/dev-server.js",
     "build": "node build/build.js",


### PR DESCRIPTION
Die `minimize` wird nicht unterstützt und somit startet das Frontend nicht und ich sehe die Fehlermeldung:

> Cannot GET /